### PR TITLE
doc: add english only to product.md

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -16,3 +16,9 @@ Serves as a starting template for developers building React applications that ne
 - Server-side rendering
 - Edge deployment capabilities
 - Modern development tooling
+
+## Language Requirements
+- **English Only**: This application targets English-speaking users
+- All UI text, labels, messages, and user-facing content must be in English
+- Source code comments and documentation should be written in English
+- Error messages and notifications must be in English


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section outlining language requirements, specifying that all user-facing content and documentation must be in English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->